### PR TITLE
Comment out timestamp in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-ven 20 mar 2015 23:54:37 CET 
+# ven 20 mar 2015 23:54:37 CET 
 
 LM35	KEYWORD1
 getTemp	KEYWORD2


### PR DESCRIPTION
It was being interpreted as a malformed keyword definition.